### PR TITLE
Fix setting temperature to below 10 degree

### DIFF
--- a/custom_components/zhisaswell/climate.py
+++ b/custom_components/zhisaswell/climate.py
@@ -213,7 +213,7 @@ class SaswellData():
                 data = '1' if value == HVAC_MODE_HEAT else '0'
             elif prop == ATTR_TEMPERATURE:
                 sensor_id = '02'
-                data = value
+                data = "%04.1f" % (float(value))
             elif prop == ATTR_PRESET_MODE:
                 sensor_id = '03'
                 data = '1' if value == PRESET_AWAY else '0'


### PR DESCRIPTION
For the temperature below 10 degree, we need to use "08.5" for 8.5 degree in the URL.
Other wise, it will set to the highest value, e.g. 35.0 degree.

设置温度为10度以下时，URL的温度数值需要加0。否则会设置成最高温度。
夏天时，我喜欢设置为最低温度。然后把面板当温度计用。